### PR TITLE
Add new release workflow to upload lambda zip as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Generate lambda zip
         run: docker-compose up
       - name: Upload lambda zip as release asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: assessment-data-import.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+---
+name: release
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install --upgrade -r requirements.txt
+      - name: Build environment
+        run: docker-compose build
+      - name: Generate lambda zip
+        run: docker-compose up
+      - name: Upload lambda zip as release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: assessment-data-import.zip
+          asset_name: assessment-data-import.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         run: docker-compose up
       - name: Upload lambda zip as release asset
         uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: assessment-data-import.zip

--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@
 that reads assessment data from a JSON file in an S3 bucket and imports it
 into a database.
 
-## Example ##
+## Building the AWS Lambda zip file ##
 
-Building the AWS Lambda zip file:
+### Via a GitHub Release ###
+
+This repository is configured with a
+[GitHub Actions](https://github.com/features/actions) release workflow that
+will automatically generate the Lambda zip file whenever a new release is
+created.  The `assessment-data-import.zip` file can be found in the list of
+assets attached to each
+[release](https://github.com/cisagov/assessment-data-import-lambda/releases).
+
+### Manually ###
 
 1. `cd ~/cisagov/assessment-data-import-lambda`
 1. `docker-compose down`


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
This PR adds a [GitHub Actions](https://github.com/features/actions) release workflow that automatically attaches the Lambda zip file to each release as an asset.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change makes it simpler to update the assessment data import lambda by eliminating the manual steps needed to create the Lambda zip file.  Now, when changes are made to this lambda, simply create a new release, let GitHub build the zip file for you, then download it to your local system and then upload it to the Lambda S3 bucket or wherever your code lives.

Ideally, a future PR will eliminate the manual steps here and automatically deploy the Lambda zip file directly to the S3 bucket where it belongs.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was successfully tested by creating a release and verifying that the correct zip file was automatically added as an asset by the GitHub actions release workflow.

## 📷 Screenshots (if appropriate)
N/A

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
